### PR TITLE
Added option to disable barrier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "layerlink"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "layerlink"
+    ]
+}

--- a/lib/src/modals.dart
+++ b/lib/src/modals.dart
@@ -49,7 +49,6 @@ void showModal(ModalEntry modalEntry) {
     } catch (e) {
       throw _routeObserverError;
     }
-
   }
 
   final overlayState = Overlay.of(context, rootOverlay: true);
@@ -106,6 +105,7 @@ class ModalEntry extends StatefulWidget {
     this.removeOnPushNext = false,
     this.barrierDismissible = false,
     this.barrierColor = Colors.transparent,
+    this.hasBarrier = true,
     this.onRemove,
     required this.child,
   })  : offset = Offset.zero,
@@ -133,6 +133,7 @@ class ModalEntry extends StatefulWidget {
     this.removeOnPushNext = false,
     this.barrierDismissible = false,
     this.barrierColor = Colors.transparent,
+    this.hasBarrier = true,
     this.onRemove,
     required this.child,
   })  : left = null,
@@ -158,6 +159,7 @@ class ModalEntry extends StatefulWidget {
     this.removeOnPushNext = false,
     this.barrierDismissible = false,
     this.barrierColor = Colors.transparent,
+    this.hasBarrier = true,
     this.onRemove,
     required this.child,
   })  : left = 0,
@@ -214,6 +216,11 @@ class ModalEntry extends StatefulWidget {
 
   /// Modal barrier color
   final Color barrierColor;
+
+  /// Enables or disables the barrier.
+  ///
+  /// Defaults to true.
+  final bool hasBarrier;
 
   /// Remove [ModalEntry] on tapping the barrier
   final bool barrierDismissible;
@@ -286,15 +293,16 @@ class ModalEntryState extends State<ModalEntry> with RouteAware {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        Positioned.fill(
-          child: IgnorePointer(
-            ignoring: !widget.barrierDismissible,
-            child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => remove(),
-                child: ColoredBox(color: widget.barrierColor)),
+        if (widget.hasBarrier)
+          Positioned.fill(
+            child: IgnorePointer(
+              ignoring: !widget.barrierDismissible,
+              child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => remove(),
+                  child: ColoredBox(color: widget.barrierColor)),
+            ),
           ),
-        ),
         if (widget._modalEntryType == _ModalEntryType.positioned)
           Positioned(
             top: widget.top,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY** (maybe need to add/modify some tests)

## Breaking Changes

NO

## Description

Added an option in the constructors for `ModalEntry` to disable the barrier. I have a use case for showing a modal without blocking the rest of the screen, and thought it might be a nice feature to have.

PS: I have only tested it with the `anchored()` constructor.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore